### PR TITLE
Add centralized error handling middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ It features:
 - **Prometheus** metrics endpoint
 - **Sentry** integration for error tracking
 - **Dockerfile** and **Kubernetes** manifests
+- **Centralized error handling** with standardized error codes
 
 ## Environment variables
 

--- a/src/errorHandler.ts
+++ b/src/errorHandler.ts
@@ -1,0 +1,15 @@
+import { Request, Response, NextFunction } from 'express';
+import * as Sentry from '@sentry/node';
+import { logger } from './logger';
+import { AppError, ErrorCode } from './errors';
+
+export function errorHandler(err: any, _req: Request, res: Response, _next: NextFunction) {
+  logger.error(err);
+  Sentry.captureException(err);
+
+  const status = err.status || 500;
+  const code = err.code || ErrorCode.INTERNAL;
+  const message = status === 500 ? 'Internal Server Error' : err.message;
+
+  res.status(status).json({ error: { code, message } });
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,14 @@
+export enum ErrorCode {
+  INTERNAL = 'INTERNAL_ERROR',
+  VALIDATION = 'VALIDATION_ERROR',
+}
+
+export class AppError extends Error {
+  code: ErrorCode;
+  status: number;
+  constructor(code: ErrorCode, message: string, status = 500) {
+    super(message);
+    this.code = code;
+    this.status = status;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,12 +5,16 @@ import { logger } from './logger';
 import { register } from './metrics';
 import { connectDB } from './db';
 import { initSentry } from './sentry';
+import { errorHandler } from './errorHandler';
+import * as Sentry from '@sentry/node';
 import dotenv from 'dotenv';
 
 dotenv.config();
 initSentry();
 
 const app = express();
+
+// Sentry is optional and initialized only when DSN is provided
 
 // logger middleware
 app.use(require('pino-http')({ logger }));
@@ -31,6 +35,9 @@ app.use('/trpc', trpcExpress.createExpressMiddleware({
   router: appRouter,
 }));
 
+// Custom error handler
+app.use(errorHandler);
+
 const port = process.env.PORT || 3000;
 
 async function start() {
@@ -41,3 +48,13 @@ async function start() {
 }
 
 start();
+
+process.on('unhandledRejection', (reason) => {
+  logger.error({ err: reason }, 'Unhandled Rejection');
+  Sentry.captureException(reason as any);
+});
+
+process.on('uncaughtException', (err) => {
+  logger.error({ err }, 'Uncaught Exception');
+  Sentry.captureException(err);
+});


### PR DESCRIPTION
## Summary
- add a small error handling module
- hook up error handler to Express
- trap unhandled rejections and exceptions
- document the new error handling feature

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68493f9eb3c4832a8875a22b0753bd17