### PR TITLE
Add user & analytics TRPC APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,5 @@ kubectl apply -f k8s/
 - `greeting` - returns a simple greeting
 - `mongoExamples` - lists `Example` records from MongoDB
 - `postgresExamples` - lists `Example` records from PostgreSQL
+- `postgresUsers` - lists `User` records from PostgreSQL
+- `mongoAnalytics` - lists analytics records from MongoDB

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "dev": "ts-node src/index.ts",
-    "prisma:generate": "prisma generate",
+    "prisma:generate": "prisma generate --schema=prisma/schema.mongo.prisma",
     "prisma:generate:postgres": "prisma generate --schema=prisma/schema.postgres.prisma"
   },
   "keywords": [],

--- a/prisma/schema.mongo.prisma
+++ b/prisma/schema.mongo.prisma
@@ -11,3 +11,9 @@ model Example {
   id   String @id @default(auto()) @map("_id") @db.ObjectId
   name String
 }
+
+model Analytics {
+  id    String @id @default(auto()) @map("_id") @db.ObjectId
+  event String
+  count Int
+}

--- a/prisma/schema.postgres.prisma
+++ b/prisma/schema.postgres.prisma
@@ -12,3 +12,9 @@ model Example {
   id   Int    @id @default(autoincrement())
   name String
 }
+
+model User {
+  id    Int    @id @default(autoincrement())
+  name  String
+  email String @unique
+}

--- a/src/trpc/router.ts
+++ b/src/trpc/router.ts
@@ -15,6 +15,14 @@ export const appRouter = t.router({
     const db = getPostgresPrisma();
     return db.example.findMany();
   }),
+  postgresUsers: t.procedure.query(async () => {
+    const db = getPostgresPrisma();
+    return db.user.findMany();
+  }),
+  mongoAnalytics: t.procedure.query(async () => {
+    const db = getMongoPrisma();
+    return db.analytics.findMany();
+  }),
 });
 
 export type AppRouter = typeof appRouter;


### PR DESCRIPTION
## Summary
- add User model to Postgres prisma schema
- add Analytics model to Mongo prisma schema
- expose `postgresUsers` and `mongoAnalytics` TRPC procedures
- document the new procedures
- rename `schema.prisma` to `schema.mongo.prisma` and update scripts

## Testing
- `npm run build`
- `npm run prisma:generate` *(fails: Failed to fetch engine file 403 Forbidden)*
- `npm run prisma:generate:postgres` *(fails: Failed to fetch engine file 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6849529ff45c832abef8102de1cf4cba