### PR TITLE
Add Prisma Mongo typings

### DIFF
--- a/src/types/prisma-mongo.d.ts
+++ b/src/types/prisma-mongo.d.ts
@@ -1,0 +1,7 @@
+declare module '../prisma/generated/mongo' {
+  export class PrismaClient {
+    $connect(): Promise<void>;
+    $disconnect(): Promise<void>;
+    [key: string]: any;
+  }
+}


### PR DESCRIPTION
## Summary
- provide Mongo Prisma Client type declarations under `src/types`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684a760be324832a945829d59b527532